### PR TITLE
Load instant.js from the root

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -108,7 +108,7 @@ export default class extends Document {
           <noscript>
             <img src="https://sa.webcloud.se/image.gif" alt="" />
           </noscript>
-          <script src="instant.js" type="module" defer />
+          <script src="/instant.js" type="module" defer />
         </body>
       </html>
     );


### PR DESCRIPTION
Your CV page is being redirected to /cv/, which is causing a 404 on instant.js.