### PR TITLE
Added slug as id prop to headings

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,9 @@
+const slug = require("rehype-slug");
 const withMDX = require("@next/mdx")({
-  extension: /\.mdx?$/
+  extension: /\.mdx?$/,
+  options: {
+    rehypePlugins: [slug]
+  }
 });
 const withBundleAnalyzer = require("@next/bundle-analyzer")({
   enabled: process.env.ANALYZE === "true"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4600,6 +4600,21 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "github-slugger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-1.3.0.tgz",
+      "integrity": "sha512-gwJScWVNhFYSRDvURk/8yhcFBee6aFjye2a7Lhb2bUyRulpIoek9p0I9Kt7PT67d/nUlZbFu8L9RLiA0woQN8Q==",
+      "requires": {
+        "emoji-regex": ">=6.0.0 <=6.1.1"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.1.1.tgz",
+          "integrity": "sha1-xs0OwbBkLio8Z6ETfvxeeW2k+I4="
+        }
+      }
+    },
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -4823,6 +4838,16 @@
         "xtend": "^4.0.1"
       }
     },
+    "hast-util-has-property": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-1.0.4.tgz",
+      "integrity": "sha512-ghHup2voGfgFoHMGnaLHOjbYFACKrRh9KFttdCzMCbFoBMJXiNi2+XTrPP8+q6cDJM/RSqlCfVWrjp1H201rZg=="
+    },
+    "hast-util-is-element": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-1.0.4.tgz",
+      "integrity": "sha512-NFR6ljJRvDcyPP5SbV7MyPBgF47X3BsskLnmw1U34yL+X6YC0MoBx9EyMg8Jtx4FzGH95jw8+c1VPLHaRA0wDQ=="
+    },
     "hast-util-parse-selector": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.3.tgz",
@@ -4854,6 +4879,11 @@
         "xtend": "^4.0.1",
         "zwitch": "^1.0.0"
       }
+    },
+    "hast-util-to-string": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-1.0.3.tgz",
+      "integrity": "sha512-3lDgDE5OdpTfP3aFeKRWEwdIZ4vprztvp+AoD+RhF7uGOBs1yBDWZFadxnjcUV4KCoI3vB9A7gdFO98hEXA90w=="
     },
     "hastscript": {
       "version": "5.1.1",
@@ -7870,6 +7900,18 @@
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
         }
+      }
+    },
+    "rehype-slug": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-3.0.0.tgz",
+      "integrity": "sha512-zFnj5BCEJXV6+URwaz8yW+9BdjDwO5iVzlQui3+7cCJ9MXlIEL0IY8VefcT/03Gw+2Hutdrx+zXnS7bnOrepZg==",
+      "requires": {
+        "github-slugger": "^1.1.1",
+        "hast-util-has-property": "^1.0.0",
+        "hast-util-is-element": "^1.0.0",
+        "hast-util-to-string": "^1.0.0",
+        "unist-util-visit": "^2.0.0"
       }
     },
     "remark-mdx": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react": "16.12.0",
     "react-dom": "16.12.0",
     "react-fela": "^11.1.2",
+    "rehype-slug": "^3.0.0",
     "uglify-js": "^3.6.9"
   },
   "devDependencies": {


### PR DESCRIPTION
Thanks to rehype-slug plugin, markdown will generate a
slug based on heading content.

This allows to link to certain part of a page eg:
/articles/my-article#some-section